### PR TITLE
fix: update GitHub Actions permissions for syncing labels

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -7,6 +7,10 @@ on:
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
No issue match